### PR TITLE
corrected the License part of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@ N/A
 ## License
 
 Please refer to the LICENSE in the repo.
+
 ---


### PR DESCRIPTION
Tenía que haber una separación entre el texto de License y los guiones del final, sino leía el texto como un header.